### PR TITLE
Miscellaneous fixes

### DIFF
--- a/templates/webapi-clean/src/CleanWebApi.WebApi/Filters/CustomExceptionFilterAttribute.cs
+++ b/templates/webapi-clean/src/CleanWebApi.WebApi/Filters/CustomExceptionFilterAttribute.cs
@@ -3,6 +3,8 @@ using System.Net;
 using CleanWebApi.WebApi.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CleanWebApi.WebApi.Filters
 {
@@ -20,6 +22,13 @@ namespace CleanWebApi.WebApi.Filters
             //         code = HttpStatusCode.NotFound;
             //         break;
             // }
+
+            // Log exception if it is a non-custom, unhandled exception
+            if (code == HttpStatusCode.InternalServerError)
+            {
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<CustomExceptionFilterAttribute>>();
+                logger.LogError(context.Exception, "Internal server error occurred");
+            }
 
             context.HttpContext.Response.ContentType = "application/json";
             context.HttpContext.Response.StatusCode = (int)code;

--- a/templates/webapi-clean/src/CleanWebApi.WebApi/Startup.cs
+++ b/templates/webapi-clean/src/CleanWebApi.WebApi/Startup.cs
@@ -65,7 +65,7 @@ namespace CleanWebApi.WebApi
                 c.SwaggerDoc("v1", new Info
                 {
                     Version = "v1",
-                    Title = "Clean Web API",
+                    Title = "CleanWebAPI",
                     Description = "ASP.NET Core Web API designed with clean architecture"
                 });
 


### PR DESCRIPTION
- Changed Swagger configuration title to "CleanWebApi" to match the template's source name. This will be replaced correctly when using the template to generate a new solution.
- Added exception logging for HTTP 500 errors in `CustomExceptionFilterAttribute.cs`.