### PR TITLE
Rename project

### DIFF
--- a/Pyrox.Templates.AspNetCore.csproj
+++ b/Pyrox.Templates.AspNetCore.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageVersion>1.0</PackageVersion>
-    <PackageId>Pyrox.CleanArchitectureTemplates</PackageId>
-    <Title>Clean Architecture Templates</Title>
+    <PackageId>Pyrox.Templates.AspNetCore</PackageId>
+    <Title>Pyrox's ASP.NET Core Templates</Title>
     <Authors>Haryz Izzudin</Authors>
-    <Description>Templates to use when creating an ASP.NET Core application with clean architecture.</Description>
+    <Description>Templates to use when creating an ASP.NET Core application.</Description>
     <PackageTags>dotnet-new;templates;clean-architecture;webapi</PackageTags>
     <TargetFramework>netcoreapp2.2</TargetFramework>
 

--- a/templates/webapi-clean/.template.config/template.json
+++ b/templates/webapi-clean/.template.config/template.json
@@ -2,7 +2,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Haryz Izzudin",
-  "classifications": [ "Web/WebAPI" ],
+  "classifications": [ "Solution/Web/WebAPI" ],
   "name": "ASP.NET Core Web API with Clean Architecture",
   "identity": "AspNetCore.WebApi.CleanArchitecture",
   "shortName": "webapi-clean",


### PR DESCRIPTION
- Renamed the project to "Pyrox.Templates.AspNetCore" for future-proofing.
- Added "Solution" to the Clean Architecture template classification for clarity.